### PR TITLE
Add exception to MD60 for numbered lists

### DIFF
--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -683,7 +683,7 @@ rule "MD060", "More than one sentence in line" do
   tags :whitespace, :emphasis
   aliases 'single-sentence'
   check do |doc|
-	  doc.matching_text_element_lines(/(?<!i\.e|e\.g)\. ./).sort
+	  doc.matching_text_element_lines(/(?<!i\.e|e\.g\d)\. ./).sort
   end
 end
 

--- a/lib/mdl/rules.rb
+++ b/lib/mdl/rules.rb
@@ -683,7 +683,7 @@ rule "MD060", "More than one sentence in line" do
   tags :whitespace, :emphasis
   aliases 'single-sentence'
   check do |doc|
-	  doc.matching_text_element_lines(/(?<!i\.e|e\.g\d)\. ./).sort
+	  doc.matching_text_element_lines(/(?<!i\.e|e\.g|\d)\. ./).sort
   end
 end
 


### PR DESCRIPTION
Exception makes sure numbered lists (e.g. 1. list item, 2. list item) don't get flagged up as a violation of rule MD60 (i.e. More than one sentence in line).
